### PR TITLE
Fix eslint crashing with typescript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,16 +5,20 @@
         "es2021": true
     },
     "extends": [
-        // "airbnb-base",
-        "oclif",
-        "oclif-typescript"
+        "plugin:@typescript-eslint/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["@typescript-eslint"],
     "parserOptions": {
         "ecmaVersion": 12
     },
     "rules": {
         "unicorn/filename-case": ["error", {"case": "camelCase"}],
         "no-console": 0,
-        "object-curly-spacing": ["error", "always"]
+        "object-curly-spacing": ["error", "always"],
+        "valid-jsdoc": 0,
+        "semi": "off",
+        "@typescript-eslint/semi": ["error"],
+        "node/no-unsupported-features/es-syntax": 0
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,15 +351,64 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
-      "integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
+      "integrity": "sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.34.0",
+        "@typescript-eslint/experimental-utils": "4.22.0",
+        "@typescript-eslint/scope-manager": "4.22.0",
+        "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.15",
         "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "4.22.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
+          "integrity": "sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/scope-manager": "4.22.0",
+            "@typescript-eslint/types": "4.22.0",
+            "@typescript-eslint/typescript-estree": "4.22.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.22.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+          "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.22.0",
+            "@typescript-eslint/visitor-keys": "4.22.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -375,24 +424,63 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
-      "integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.0.tgz",
+      "integrity": "sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==",
       "dev": true,
       "requires": {
-        "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.34.0",
-        "@typescript-eslint/typescript-estree": "2.34.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "@typescript-eslint/scope-manager": "4.22.0",
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/typescript-estree": "4.22.0",
+        "debug": "^4.1.1"
       },
       "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.22.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+          "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.22.0",
+            "@typescript-eslint/visitor-keys": "4.22.0",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
         }
       }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+      "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/visitor-keys": "4.22.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+      "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+      "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "2.34.0",
@@ -415,6 +503,16 @@
           "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+      "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.22.0",
+        "eslint-visitor-keys": "^2.0.0"
       }
     },
     "acorn": {
@@ -1148,6 +1246,38 @@
         "eslint-plugin-mocha": "^5.2.0",
         "eslint-plugin-node": "^7.0.1",
         "eslint-plugin-unicorn": "^6.0.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": {
+          "version": "2.34.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
+          "integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/experimental-utils": "2.34.0",
+            "functional-red-black-tree": "^1.0.1",
+            "regexpp": "^3.0.0",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "2.34.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
+          "integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
+          "dev": true,
+          "requires": {
+            "@types/eslint-visitor-keys": "^1.0.0",
+            "@typescript-eslint/experimental-utils": "2.34.0",
+            "@typescript-eslint/typescript-estree": "2.34.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-config-xo": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "@oclif/dev-cli": "^1.26.0",
     "@types/node": "^10.17.56",
+    "@typescript-eslint/eslint-plugin": "^4.22.0",
+    "@typescript-eslint/parser": "^4.22.0",
     "eslint": "^7.24.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-oclif": "^3.1.0",

--- a/src/aws/getCredentials.js
+++ b/src/aws/getCredentials.js
@@ -1,11 +1,11 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
 async function isAuthenticated() {
   return new Promise(resolve => {
     AWS.config.getCredentials((err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = isAuthenticated
+module.exports = isAuthenticated;

--- a/src/aws/index.js
+++ b/src/aws/index.js
@@ -1,15 +1,15 @@
-const createBucket = require('./s3/createBucket')
-const deleteBucket = require('./s3/deleteBucket')
-const createLambda = require('./lambda/createLambda')
-const createLambdaRole = require('./lambda/createLambdaRole')
-const listLambdas = require('./lambda/listLambdas')
-const setLambdaInvokePolicy = require('./lambda/setLambdaInvokePolicy')
-const attachLambdaBasicExecutionPolicy = require('./lambda/attachLambdaBasicExecutionPolicy')
-const createS3LambdaTrigger = require('./s3/createS3LambdaTrigger')
-const uploadToBucket = require('./s3/uploadToBucket')
-const getCredentials = require('./getCredentials')
-const createTimestreamDatabase = require('./timestream/createTimestreamDatabase')
-const createTimestreamTable = require('./timestream/createTimestreamTable')
+const createBucket = require('./s3/createBucket');
+const deleteBucket = require('./s3/deleteBucket');
+const createLambda = require('./lambda/createLambda');
+const createLambdaRole = require('./lambda/createLambdaRole');
+const listLambdas = require('./lambda/listLambdas');
+const setLambdaInvokePolicy = require('./lambda/setLambdaInvokePolicy');
+const attachLambdaBasicExecutionPolicy = require('./lambda/attachLambdaBasicExecutionPolicy');
+const createS3LambdaTrigger = require('./s3/createS3LambdaTrigger');
+const uploadToBucket = require('./s3/uploadToBucket');
+const getCredentials = require('./getCredentials');
+const createTimestreamDatabase = require('./timestream/createTimestreamDatabase');
+const createTimestreamTable = require('./timestream/createTimestreamTable');
 
 module.exports = {
   createBucket,
@@ -24,4 +24,4 @@ module.exports = {
   getCredentials,
   createTimestreamDatabase,
   createTimestreamTable,
-}
+};

--- a/src/aws/lambda/attachLambdaBasicExecutionPolicy.js
+++ b/src/aws/lambda/attachLambdaBasicExecutionPolicy.js
@@ -1,18 +1,18 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
-const iam = new AWS.IAM()
+const iam = new AWS.IAM();
 
 function attachLambdaBasicExecutionPolicy(RoleName) {
   return new Promise(resolve => {
     const params = {
       PolicyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
       RoleName,
-    }
+    };
 
     iam.attachRolePolicy(params, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = attachLambdaBasicExecutionPolicy
+module.exports = attachLambdaBasicExecutionPolicy;

--- a/src/aws/lambda/createLambda.js
+++ b/src/aws/lambda/createLambda.js
@@ -1,8 +1,8 @@
-const fs = require('fs')
+const fs = require('fs');
 
-const path = require('path')
-const AWS = require('aws-sdk')
-const AdmZip = require('adm-zip')
+const path = require('path');
+const AWS = require('aws-sdk');
+const AdmZip = require('adm-zip');
 
 function createLambda({
   lambdaFile,
@@ -12,22 +12,22 @@ function createLambda({
   Description = '',
 }) {
   return new Promise(resolve => {
-    AWS.config.update({region})
+    AWS.config.update({ region });
 
-    const lambdaName = lambdaFile.replace(/\.js/, '')
+    const lambdaName = lambdaFile.replace(/\.js/, '');
 
     if (!fs.existsSync(lambdaFile)) {
-      throw new Error("Can't find lambda file")
+      throw new Error("Can't find lambda file");
     }
 
-    const zip = new AdmZip()
+    const zip = new AdmZip();
 
-    zip.addLocalFile(lambdaFile)
+    zip.addLocalFile(lambdaFile);
 
-    const lambda = new AWS.Lambda()
+    const lambda = new AWS.Lambda();
 
     const params = {
-      Code: {/* required */
+      Code: { /* required */
         ZipFile: zip.toBuffer(),
       },
       FunctionName: path.basename(lambdaName), /* required */
@@ -35,12 +35,12 @@ function createLambda({
       Role, /* required */
       Runtime, /* required */
       Description,
-    }
+    };
 
     lambda.createFunction(params, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = createLambda
+module.exports = createLambda;

--- a/src/aws/lambda/createLambdaRole.js
+++ b/src/aws/lambda/createLambdaRole.js
@@ -1,6 +1,6 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
-const iam = new AWS.IAM()
+const iam = new AWS.IAM();
 
 function createLambdaRole(RoleName) {
   return new Promise(resolve => {
@@ -23,12 +23,12 @@ function createLambdaRole(RoleName) {
       }),
       Path: '/',
       RoleName,
-    }
+    };
 
     iam.createRole(params, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = createLambdaRole
+module.exports = createLambdaRole;

--- a/src/aws/lambda/listLambdas.js
+++ b/src/aws/lambda/listLambdas.js
@@ -1,16 +1,16 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
-AWS.config.update({region: 'us-east-1'})
+AWS.config.update({ region: 'us-east-1' });
 
-const lambda = new AWS.Lambda()
+const lambda = new AWS.Lambda();
 
 function listLambdas() {
   return new Promise(resolve => {
     lambda.listFunctions((err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = listLambdas
+module.exports = listLambdas;
 

--- a/src/aws/lambda/setLambdaInvokePolicy.js
+++ b/src/aws/lambda/setLambdaInvokePolicy.js
@@ -1,4 +1,4 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
 function setLambdaInvokePolicy(
   Arn,
@@ -6,23 +6,23 @@ function setLambdaInvokePolicy(
   region = 'us-east-1',
 ) {
   return new Promise(resolve => {
-    AWS.config.update({region})
+    AWS.config.update({ region });
 
     // Creates Lambda Function Policy which must be created once for each Lambda function
     // Must be done before calling s3.putBucketNotificationConfiguration(...)
-    const lambda = new AWS.Lambda()
+    const lambda = new AWS.Lambda();
 
     const params = {
       Action: 'lambda:InvokeFunction',
       FunctionName: Arn,
       Principal: 's3.amazonaws.com',
       StatementId,
-    }
+    };
 
     lambda.addPermission(params, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = setLambdaInvokePolicy
+module.exports = setLambdaInvokePolicy;

--- a/src/aws/s3/createBucket.js
+++ b/src/aws/s3/createBucket.js
@@ -1,20 +1,20 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
-const s3 = new AWS.S3()
+const s3 = new AWS.S3();
 
 function createBucket(bucketName, region = 'us-east-1') {
   return new Promise(resolve => {
-    AWS.config.update({region})
+    AWS.config.update({ region });
 
     const bucketParams = {
       Bucket: bucketName,
-    }
+    };
 
     s3.createBucket(bucketParams, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = createBucket
+module.exports = createBucket;
 

--- a/src/aws/s3/createS3LambdaTrigger.js
+++ b/src/aws/s3/createS3LambdaTrigger.js
@@ -3,9 +3,9 @@
  * trigger one lambda
 */
 
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
-const s3 = new AWS.S3()
+const s3 = new AWS.S3();
 
 function createS3LambdaTrigger(Bucket, LambdaFunctionArn) {
   return new Promise(resolve => {
@@ -20,12 +20,12 @@ function createS3LambdaTrigger(Bucket, LambdaFunctionArn) {
           },
         ],
       },
-    }
+    };
 
     s3.putBucketNotificationConfiguration(params, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = createS3LambdaTrigger
+module.exports = createS3LambdaTrigger;

--- a/src/aws/s3/deleteBucket.js
+++ b/src/aws/s3/deleteBucket.js
@@ -1,19 +1,19 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
-const s3 = new AWS.S3({apiVersion: '2006-03-01'})
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 function deleteBucket(Bucket, region = 'us-east-1') {
   return new Promise(resolve => {
-    AWS.config.update({region})
+    AWS.config.update({ region });
 
     const bucketParams = {
       Bucket,
-    }
+    };
 
     s3.deleteBucket(bucketParams, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = deleteBucket
+module.exports = deleteBucket;

--- a/src/aws/s3/uploadToBucket.js
+++ b/src/aws/s3/uploadToBucket.js
@@ -1,31 +1,31 @@
-const path = require('path')
-const fs = require('fs')
+const path = require('path');
+const fs = require('fs');
 
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
-const s3 = new AWS.S3({apiVersion: '2006-03-01'})
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 function uploadToBucket(Bucket, file, region = 'us-east-1') {
   return new Promise(resolve => {
-    AWS.config.update({region})
+    AWS.config.update({ region });
 
-    const uploadParams = {Bucket, Key: '', Body: ''}
+    const uploadParams = { Bucket, Key: '', Body: '' };
 
-    if (!fs.existsSync(file)) throw new Error('Cannot open file')
+    if (!fs.existsSync(file)) throw new Error('Cannot open file');
 
-    const fileStream = fs.createReadStream(file)
+    const fileStream = fs.createReadStream(file);
 
     fileStream.on('error', err => {
-      throw new Error(err)
-    })
+      throw new Error(err);
+    });
 
-    uploadParams.Body = fileStream
-    uploadParams.Key = path.basename(file)
+    uploadParams.Body = fileStream;
+    uploadParams.Key = path.basename(file);
 
     s3.upload(uploadParams, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = uploadToBucket
+module.exports = uploadToBucket;

--- a/src/aws/timestream/createTimestreamDatabase.js
+++ b/src/aws/timestream/createTimestreamDatabase.js
@@ -1,19 +1,19 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
 function createTimestreamDatabase(DatabaseName, region = 'us-east-1') {
   return new Promise(resolve => {
-    AWS.config.update({region})
+    AWS.config.update({ region });
 
-    const Timestream = new AWS.TimestreamWrite()
+    const Timestream = new AWS.TimestreamWrite();
 
     const params = {
       DatabaseName,
-    }
+    };
 
     Timestream.createDatabase(params, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = createTimestreamDatabase
+module.exports = createTimestreamDatabase;

--- a/src/aws/timestream/createTimestreamTable.js
+++ b/src/aws/timestream/createTimestreamTable.js
@@ -1,4 +1,4 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 
 function createTimestreamTable({
   DatabaseName,
@@ -9,9 +9,9 @@ function createTimestreamTable({
   region = 'us-east-1',
 }) {
   return new Promise(resolve => {
-    AWS.config.update({region})
+    AWS.config.update({ region });
 
-    const Timestream = new AWS.TimestreamWrite()
+    const Timestream = new AWS.TimestreamWrite();
 
     const params = {
       DatabaseName, /* required */
@@ -21,11 +21,11 @@ function createTimestreamTable({
         MemoryStoreRetentionPeriodInHours, /* required */
       },
       Tags,
-    }
+    };
     Timestream.createTable(params, (err, data) => {
-      resolve([err, data])
-    })
-  })
+      resolve([err, data]);
+    });
+  });
 }
 
-module.exports = createTimestreamTable
+module.exports = createTimestreamTable;

--- a/src/commands/hello.ts
+++ b/src/commands/hello.ts
@@ -1,31 +1,31 @@
-import {Command, flags} from '@oclif/command'
+import { Command, flags } from '@oclif/command';
 
 export default class Hello extends Command {
-  static description = 'describe the command here'
+  static description = 'describe the command here';
 
   static examples = [
     `$ dendro hello
 hello world from ./src/hello.ts!
 `,
-  ]
+  ];
 
   static flags = {
-    help: flags.help({char: 'h'}),
+    help: flags.help({ char: 'h' }),
     // flag with a value (-n, --name=VALUE)
-    name: flags.string({char: 'n', description: 'name to print'}),
+    name: flags.string({ char: 'n', description: 'name to print' }),
     // flag with no value (-f, --force)
-    force: flags.boolean({char: 'f'}),
-  }
+    force: flags.boolean({ char: 'f' }),
+  };
 
-  static args = [{name: 'file'}]
+  static args = [{ name: 'file' }];
 
   async run() {
-    const {args, flags} = this.parse(Hello)
+    const { args, flags } = this.parse(Hello);
 
-    const name = flags.name ?? 'world'
-    this.log(`hello ${name} from ./src/commands/hello.ts`)
+    const name = flags.name ?? 'world';
+    this.log(`hello ${name} from ./src/commands/hello.ts`);
     if (args.file && flags.force) {
-      this.log(`you input --force and --file: ${args.file}`)
+      this.log(`you input --force and --file: ${args.file}`);
     }
   }
 }

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -2,85 +2,85 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
 
-const {Command, flags} = require('@oclif/command')
+const { Command, flags } = require('@oclif/command');
 
-const AWSWrapper = require('../aws')
+const AWSWrapper = require('../aws');
 
-const NEW_ROLE_NAME = 'dendro-lambda-role'
-const NEW_BUCKET_NAME = 'dendrodefaultbucket'
-const PATH_TO_LAMBDA_FUNCTION = './aws/lambda/_deployableLambdaFunction.js'
-const FILE_TO_UPLOAD = './aws/s3/uploadToBucket.js'
+const NEW_ROLE_NAME = 'dendro-lambda-role';
+const NEW_BUCKET_NAME = 'dendrodefaultbucket';
+const PATH_TO_LAMBDA_FUNCTION = './aws/lambda/_deployableLambdaFunction.js';
+const FILE_TO_UPLOAD = './aws/s3/uploadToBucket.js';
 
 class TestCommand extends Command {
   async run() {
-    const parsed = this.parse(TestCommand)
-    const name = parsed.flags.name || 'world'
-    this.log(`test ${name} from ./src/commands/test.js`)
+    const parsed = this.parse(TestCommand);
+    const name = parsed.flags.name || 'world';
+    this.log(`test ${name} from ./src/commands/test.js`);
 
-    console.log('Creating new lambda role...')
-    const [lambdaRoleErr, lambdaRole] = await AWSWrapper.createLambdaRole(NEW_ROLE_NAME)
+    console.log('Creating new lambda role...');
+    const [lambdaRoleErr, lambdaRole] = await AWSWrapper.createLambdaRole(NEW_ROLE_NAME);
     if (lambdaRoleErr) {
-      console.error(lambdaRoleErr)
+      console.error(lambdaRoleErr);
     } else {
-      console.log('success')
+      console.log('success');
     }
-    console.log(lambdaRole.Role.Arn)
+    console.log(lambdaRole.Role.Arn);
 
-    console.log('Attaching AWSLambdaBasicExecutionRole...')
-    const [attachPolicyErr, attachPolicyData] = await AWSWrapper.attachLambdaBasicExecutionPolicy(NEW_ROLE_NAME)
+    console.log('Attaching AWSLambdaBasicExecutionRole...');
+    const [attachPolicyErr, attachPolicyData] = await AWSWrapper.attachLambdaBasicExecutionPolicy(NEW_ROLE_NAME);
     if (attachPolicyErr) {
-      console.error(attachPolicyErr)
+      console.error(attachPolicyErr);
     } else {
-      console.log('success')
+      console.log('success');
     }
     // console.log(attachPolicyData)
 
-    console.log('Creating new lambda...')
+    console.log('Creating new lambda...');
     const [lambdaErr, lambdaData] = await AWSWrapper.createLambda({
       lambdaFile: PATH_TO_LAMBDA_FUNCTION,
       Role: 'arn:aws:iam::141351053848:role/dendro-lambda-role',
-    })
+    });
     if (lambdaErr) {
-      console.error(lambdaErr)
+      console.error(lambdaErr);
     } else {
-      console.log('success')
+      console.log('success');
     }
-    console.log(lambdaData)
+    console.log(lambdaData);
 
-    console.log('Creating new bucket...')
+    console.log('Creating new bucket...');
 
-    const [bucketErr, bucketData] = await AWSWrapper.createBucket(NEW_BUCKET_NAME)
+    const [bucketErr, bucketData] = await AWSWrapper.createBucket(NEW_BUCKET_NAME);
     if (bucketErr) {
-      console.error(bucketErr)
+      console.error(bucketErr);
     } else {
-      console.log('success')
+      console.log('success');
     }
     // console.log(bucketData)
 
-    console.log('Setting lambda invoke policy...')
-    const [policyErr, policyData] = await AWSWrapper.setLambdaInvokePolicy(lambdaData.FunctionArn)
+    console.log('Setting lambda invoke policy...');
+    const [policyErr, policyData] = await AWSWrapper.setLambdaInvokePolicy(lambdaData.FunctionArn);
     if (policyErr) {
-      console.error(policyErr)
+      console.error(policyErr);
     } else {
-      console.log('success')
+      console.log('success');
     }
     // console.log(policyData)
 
-    console.log('Creating S3 trigger...')
-    const [triggerErr, triggerData] = await AWSWrapper.createS3LambdaTrigger(NEW_BUCKET_NAME, lambdaData.FunctionArn)
+    console.log('Creating S3 trigger...');
+    const [triggerErr, triggerData] = await AWSWrapper.createS3LambdaTrigger(NEW_BUCKET_NAME, lambdaData.FunctionArn);
     if (triggerErr) {
-      console.error(triggerErr)
+      console.error(triggerErr);
     } else {
-      console.log('success')
+      console.log('success');
     }
     // console.log(triggerData)
 
-    console.log('Uploading to S3...')
-    const [uploadErr, uploadData] = await AWSWrapper.uploadToBucket(NEW_BUCKET_NAME, FILE_TO_UPLOAD)
+    console.log('Uploading to S3...');
+    const [uploadErr, uploadData] = await AWSWrapper.uploadToBucket(NEW_BUCKET_NAME, FILE_TO_UPLOAD);
     if (uploadErr) {
-      console.error(uploadErr)
+      console.error(uploadErr);
     } else {
-      console.log('success')
+      console.log('success');
     }
     // console.log(uploadData)
 
@@ -98,10 +98,10 @@ class TestCommand extends Command {
 TestCommand.description = `Describe the command here
 ...
 Extra documentation goes here
-`
+`;
 
 TestCommand.flags = {
-  name: flags.string({char: 'n', description: 'name to print'}),
-}
+  name: flags.string({ char: 'n', description: 'name to print' }),
+};
 
-module.exports = TestCommand
+module.exports = TestCommand;

--- a/src/globalState/aws/credentials.ts
+++ b/src/globalState/aws/credentials.ts
@@ -12,9 +12,9 @@ class Credentials {
   secretAccessKey?: string;
 
   constructor({ accessKeyId, secretAccessKey }: CredentialsData) {
-    this.accessKeyId = accessKeyId
-    this.secretAccessKey = secretAccessKey
+    this.accessKeyId = accessKeyId;
+    this.secretAccessKey = secretAccessKey;
   }
 }
 
-export default Credentials
+export default Credentials;

--- a/src/globalState/aws/firehose.ts
+++ b/src/globalState/aws/firehose.ts
@@ -10,4 +10,4 @@ class Firehose {
   constructor({}: FirehoseData) {}
 }
 
-export default Firehose
+export default Firehose;

--- a/src/globalState/aws/index.ts
+++ b/src/globalState/aws/index.ts
@@ -1,8 +1,8 @@
-import Credentials, { CredentialsData } from './credentials'
-import Lambda, { LambdaData } from './lambda'
-import S3, { S3Data } from './s3'
-import Firehose, { FirehoseData } from './firehose'
-import Timestream, { TimestreamData } from './timestream'
+import Credentials, { CredentialsData } from './credentials';
+import Lambda, { LambdaData } from './lambda';
+import S3, { S3Data } from './s3';
+import Firehose, { FirehoseData } from './firehose';
+import Timestream, { TimestreamData } from './timestream';
 
 export interface AWSData {
   credentials: CredentialsData;
@@ -13,7 +13,7 @@ export interface AWSData {
 }
 
 class AWS {
-  Credentials: Credentials
+  Credentials: Credentials;
 
   Lambda: Lambda;
 
@@ -30,12 +30,12 @@ class AWS {
     firehose = {},
     timestream = {},
   }: AWSData) {
-    this.Credentials = new Credentials(credentials)
-    this.Lambda = new Lambda(lambda)
-    this.S3 = new S3(s3)
-    this.Firehose = new Firehose(firehose)
-    this.Timestream = new Timestream(timestream)
+    this.Credentials = new Credentials(credentials);
+    this.Lambda = new Lambda(lambda);
+    this.S3 = new S3(s3);
+    this.Firehose = new Firehose(firehose);
+    this.Timestream = new Timestream(timestream);
   }
 }
 
-export default AWS
+export default AWS;

--- a/src/globalState/aws/lambda.ts
+++ b/src/globalState/aws/lambda.ts
@@ -12,10 +12,10 @@ class Lambda {
     Policy,
     FunctionData,
   }: LambdaData) {
-    this.Role = Role
-    this.Policy = Policy
-    this.FunctionData = FunctionData
+    this.Role = Role;
+    this.Policy = Policy;
+    this.FunctionData = FunctionData;
   }
 }
 
-export default Lambda
+export default Lambda;

--- a/src/globalState/aws/s3.ts
+++ b/src/globalState/aws/s3.ts
@@ -10,4 +10,4 @@ class S3 {
   constructor({}: S3Data) {}
 }
 
-export default S3
+export default S3;

--- a/src/globalState/aws/timestream.ts
+++ b/src/globalState/aws/timestream.ts
@@ -10,4 +10,4 @@ class Timestream {
   constructor({}: TimestreamData) {}
 }
 
-export default Timestream
+export default Timestream;

--- a/src/globalState/index.ts
+++ b/src/globalState/index.ts
@@ -1,5 +1,5 @@
-import AWS, { AWSData } from './aws'
-import Vector, { VectorData } from './vector'
+import AWS, { AWSData } from './aws';
+import Vector, { VectorData } from './vector';
 
 /*
  * GlobalState is an singleton that will contain all data over the lifetime
@@ -8,7 +8,7 @@ import Vector, { VectorData } from './vector'
  * during initialization.
  */
 class GlobalState {
-  AWS: AWS
+  AWS: AWS;
 
   Vector: Vector;
 
@@ -16,8 +16,8 @@ class GlobalState {
     aws,
     vector,
   }: CacheData) {
-    this.AWS = new AWS(aws)
-    this.Vector = new Vector(vector)
+    this.AWS = new AWS(aws);
+    this.Vector = new Vector(vector);
   }
 
   /*
@@ -25,7 +25,7 @@ class GlobalState {
    * This function will dump the current state to the cache to prevent data loss.
    */
   dump() {
-    console.log(this)
+    console.log(this);
   }
 }
 
@@ -51,6 +51,6 @@ const cache: CacheData = {
     postgres: {},
     nginx: {},
   },
-}
+};
 
-export default new GlobalState(cache)
+export default new GlobalState(cache);

--- a/src/globalState/vector/apache.ts
+++ b/src/globalState/vector/apache.ts
@@ -28,13 +28,13 @@ class Apache {
     monitorErrorLogs = false,
     monitorMetrics = false,
   }: ApacheData) {
-    this.port = port
-    this.url = url
-    this.scrapeInterval = scrapeInterval
-    this.monitorAccessLogs = monitorAccessLogs
-    this.monitorErrorLogs = monitorErrorLogs
-    this.monitorMetrics = monitorMetrics
+    this.port = port;
+    this.url = url;
+    this.scrapeInterval = scrapeInterval;
+    this.monitorAccessLogs = monitorAccessLogs;
+    this.monitorErrorLogs = monitorErrorLogs;
+    this.monitorMetrics = monitorMetrics;
   }
 }
 
-export default Apache
+export default Apache;

--- a/src/globalState/vector/customApplication.ts
+++ b/src/globalState/vector/customApplication.ts
@@ -9,9 +9,9 @@ class CustomApplication {
   filepath: string;
 
   constructor({ name, filepath }: CustomApplicationData) {
-    this.name = name
-    this.filepath = filepath
+    this.name = name;
+    this.filepath = filepath;
   }
 }
 
-export default CustomApplication
+export default CustomApplication;

--- a/src/globalState/vector/host.ts
+++ b/src/globalState/vector/host.ts
@@ -21,7 +21,7 @@ class Host {
 
   memory: boolean;
 
-  network: boolean
+  network: boolean;
 
   constructor({
     cpu = false,
@@ -32,29 +32,29 @@ class Host {
     memory = false,
     network = false,
   }: HostData) {
-    this.cpu = cpu
-    this.disk = disk
-    this.filesystem = filesystem
-    this.load = load
-    this.host = host
-    this.memory = memory
-    this.network = network
+    this.cpu = cpu;
+    this.disk = disk;
+    this.filesystem = filesystem;
+    this.load = load;
+    this.host = host;
+    this.memory = memory;
+    this.network = network;
   }
 
   /*
    * Helps identify if a host vector config should be built
    */
   shouldBuildConfig(): boolean {
-    if (this.cpu) return true
-    if (this.disk) return true
-    if (this.filesystem) return true
-    if (this.load) return true
-    if (this.host) return true
-    if (this.memory) return true
-    if (this.network) return true
+    if (this.cpu) return true;
+    if (this.disk) return true;
+    if (this.filesystem) return true;
+    if (this.load) return true;
+    if (this.host) return true;
+    if (this.memory) return true;
+    if (this.network) return true;
 
-    return false
+    return false;
   }
 }
 
-export default Host
+export default Host;

--- a/src/globalState/vector/index.ts
+++ b/src/globalState/vector/index.ts
@@ -1,9 +1,9 @@
-import Postgres, { PostgresData } from './postgres'
-import Nginx, { NginxData } from './nginx'
-import Apache, { ApacheData } from './apache'
-import Host, { HostData } from './host'
-import Mongo, { MongoData } from './mongo'
-import CustomApplication, { CustomApplicationData } from './customApplication'
+import Postgres, { PostgresData } from './postgres';
+import Nginx, { NginxData } from './nginx';
+import Apache, { ApacheData } from './apache';
+import Host, { HostData } from './host';
+import Mongo, { MongoData } from './mongo';
+import CustomApplication, { CustomApplicationData } from './customApplication';
 
 export interface VectorData {
   postgres?: PostgresData;
@@ -33,19 +33,19 @@ class Vector {
     host = {},
     mongo = {},
   }: VectorData) {
-    this.Postgres = new Postgres(postgres)
-    this.Nginx = new Nginx(nginx)
-    this.Apache = new Apache(apache)
-    this.Host = new Host(host)
-    this.Mongo = new Mongo(mongo)
-    this.CustomApplications = []
+    this.Postgres = new Postgres(postgres);
+    this.Nginx = new Nginx(nginx);
+    this.Apache = new Apache(apache);
+    this.Host = new Host(host);
+    this.Mongo = new Mongo(mongo);
+    this.CustomApplications = [];
   }
 
   setCustomApp(data: CustomApplicationData) {
     this.CustomApplications.push(
       new CustomApplication(data),
-    )
+    );
   }
 }
 
-export default Vector
+export default Vector;

--- a/src/globalState/vector/mongo.ts
+++ b/src/globalState/vector/mongo.ts
@@ -24,12 +24,12 @@ class Mongo {
     monitorLogs = false,
     monitorMetrics = false,
   }: MongoData) {
-    this.port = port
-    this.url = url
-    this.scrapeInterval = scrapeInterval
-    this.monitorLogs = monitorLogs
-    this.monitorMetrics = monitorMetrics
+    this.port = port;
+    this.url = url;
+    this.scrapeInterval = scrapeInterval;
+    this.monitorLogs = monitorLogs;
+    this.monitorMetrics = monitorMetrics;
   }
 }
 
-export default Mongo
+export default Mongo;

--- a/src/globalState/vector/nginx.ts
+++ b/src/globalState/vector/nginx.ts
@@ -28,13 +28,13 @@ class Nginx {
     monitorErrorLogs = false,
     monitorMetrics = false,
   }: NginxData) {
-    this.port = port
-    this.url = url
-    this.scrapeInterval = scrapeInterval
-    this.monitorAccessLogs = monitorAccessLogs
-    this.monitorErrorLogs = monitorErrorLogs
-    this.monitorMetrics = monitorMetrics
+    this.port = port;
+    this.url = url;
+    this.scrapeInterval = scrapeInterval;
+    this.monitorAccessLogs = monitorAccessLogs;
+    this.monitorErrorLogs = monitorErrorLogs;
+    this.monitorMetrics = monitorMetrics;
   }
 }
 
-export default Nginx
+export default Nginx;

--- a/src/globalState/vector/postgres.ts
+++ b/src/globalState/vector/postgres.ts
@@ -36,15 +36,15 @@ class Postgres {
     monitorErrorLogs = false,
     monitorMetrics = false,
   }: PostgresData) {
-    this.username = username
-    this.password = password
-    this.port = port
-    this.url = url
-    this.databaseName = databaseName
-    this.scrapeInterval = scrapeInterval
-    this.monitorErrorLogs = monitorErrorLogs
-    this.monitorMetrics = monitorMetrics
+    this.username = username;
+    this.password = password;
+    this.port = port;
+    this.url = url;
+    this.databaseName = databaseName;
+    this.scrapeInterval = scrapeInterval;
+    this.monitorErrorLogs = monitorErrorLogs;
+    this.monitorMetrics = monitorMetrics;
   }
 }
 
-export default Postgres
+export default Postgres;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { run } from '@oclif/command'
+export { run } from '@oclif/command';

--- a/src/utils/aws.ts
+++ b/src/utils/aws.ts
@@ -1,4 +1,4 @@
-import globalState from '../globalState'
+import globalState from '../globalState';
 
 /**
  * Used to ensure aws credentials exist prior to doing some operation
@@ -11,7 +11,7 @@ export const ensureCredentials = (msg: string) => {
     !globalState.AWS.Credentials.accessKeyId ||
     !globalState.AWS.Credentials.secretAccessKey
   ) {
-    console.log(globalState.AWS)
-    throw new Error(msg)
+    console.log(globalState.AWS);
+    throw new Error(msg);
   }
-}
+};

--- a/src/vector/configs/apache.ts
+++ b/src/vector/configs/apache.ts
@@ -1,30 +1,30 @@
-import globalState from '../../globalState'
+import globalState from '../../globalState';
 
 // TODO
 const logConfig = (): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 // TODO
 const metricConfig = (): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 export const buildApacheConfig = (): string => {
-  let config = ''
+  let config = '';
 
   if (globalState.Vector.Apache.monitorMetrics) {
-    config += metricConfig()
+    config += metricConfig();
   }
 
   if (
     globalState.Vector.Apache.monitorAccessLogs ||
     globalState.Vector.Apache.monitorErrorLogs
   ) {
-    config += logConfig()
+    config += logConfig();
   }
 
-  return config
-}
+  return config;
+};

--- a/src/vector/configs/customApplication.ts
+++ b/src/vector/configs/customApplication.ts
@@ -1,20 +1,20 @@
-import globalState from '../../globalState'
-import { CustomApplicationData } from '../../globalState/vector/customApplication'
+import globalState from '../../globalState';
+import { CustomApplicationData } from '../../globalState/vector/customApplication';
 
 // TODO
 const logConfig = ({ name, filepath }: CustomApplicationData): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 export const buildHostConfig = (): string => {
-  let config = ''
+  let config = '';
 
   if (globalState.Vector.CustomApplications) {
     globalState.Vector.CustomApplications.forEach(customApp => {
-      config += logConfig(customApp)
-    })
+      config += logConfig(customApp);
+    });
   }
 
-  return config
-}
+  return config;
+};

--- a/src/vector/configs/host.ts
+++ b/src/vector/configs/host.ts
@@ -1,15 +1,15 @@
-import globalState from '../../globalState'
+import globalState from '../../globalState';
 
 // TODO
 const config = (): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 export const buildHostConfig = (): string => {
   if (globalState.Vector.Host.shouldBuildConfig()) {
-    return config()
+    return config();
   }
 
-  return ''
-}
+  return '';
+};

--- a/src/vector/configs/mongo.ts
+++ b/src/vector/configs/mongo.ts
@@ -1,27 +1,27 @@
-import globalState from '../../globalState'
+import globalState from '../../globalState';
 
 // TODO
 const logConfig = (): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 // TODO
 const metricConfig = (): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 export const buildMongoConfig = (): string => {
-  let config = ''
+  let config = '';
 
   if (globalState.Vector.Mongo.monitorMetrics) {
-    config += metricConfig()
+    config += metricConfig();
   }
 
   if (globalState.Vector.Mongo.monitorLogs) {
-    config += logConfig()
+    config += logConfig();
   }
 
-  return config
-}
+  return config;
+};

--- a/src/vector/configs/nginx.ts
+++ b/src/vector/configs/nginx.ts
@@ -1,4 +1,4 @@
-import globalState from '../../globalState'
+import globalState from '../../globalState';
 
 const logConfig = (): string => {
   return `
@@ -33,28 +33,28 @@ encoding.codec = "json" # required
 healthcheck.enabled = true # optional, default
 
 #############################################\n
-    `
-}
+    `;
+};
 
 // TODO
 const metricConfig = (): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 export const buildNginxConfig = (): string => {
-  let config = ''
+  let config = '';
 
   if (globalState.Vector.Nginx.monitorMetrics) {
-    config += metricConfig()
+    config += metricConfig();
   }
 
   if (
     globalState.Vector.Nginx.monitorAccessLogs ||
     globalState.Vector.Nginx.monitorErrorLogs
   ) {
-    config += logConfig()
+    config += logConfig();
   }
 
-  return config
-}
+  return config;
+};

--- a/src/vector/configs/postgres.ts
+++ b/src/vector/configs/postgres.ts
@@ -1,4 +1,4 @@
-import globalState from '../../globalState'
+import globalState from '../../globalState';
 
 const logConfig = (): string => {
   return `
@@ -30,25 +30,25 @@ encoding.codec = "json" # required
 healthcheck.enabled = true # optional, default
 
 #############################################\n
-    `
-}
+    `;
+};
 
 // TODO
 const metricConfig = (): string => {
-  console.log('Not Implemented')
-  return ''
-}
+  console.log('Not Implemented');
+  return '';
+};
 
 export const buildPostgresConfig = (): string => {
-  let config = ''
+  let config = '';
 
   if (globalState.Vector.Postgres?.monitorMetrics) {
-    config += metricConfig()
+    config += metricConfig();
   }
 
   if (globalState.Vector.Postgres?.monitorErrorLogs) {
-    config += logConfig()
+    config += logConfig();
   }
 
-  return config
-}
+  return config;
+};

--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -1,25 +1,25 @@
-import { ensureCredentials } from '../utils/aws'
+import { ensureCredentials } from '../utils/aws';
 
-import { buildApacheConfig } from './configs/apache'
-import { buildHostConfig } from './configs/host'
-import { buildMongoConfig } from './configs/mongo'
-import { buildNginxConfig } from './configs/nginx'
-import { buildPostgresConfig } from './configs/postgres'
+import { buildApacheConfig } from './configs/apache';
+import { buildHostConfig } from './configs/host';
+import { buildMongoConfig } from './configs/mongo';
+import { buildNginxConfig } from './configs/nginx';
+import { buildPostgresConfig } from './configs/postgres';
 
 /**
  * Build the vector config file based on the current global state
  * @returns {String} the vector config file ready to write to disk
  */
 export const buildVectorConfig = (): string => {
-  ensureCredentials('Tried writing vector configs without aws credentials existing.')
+  ensureCredentials('Tried writing vector configs without aws credentials existing.');
 
-  let config = ''
-  config += buildApacheConfig()
+  let config = '';
+  config += buildApacheConfig();
   // config += buildCustomApplications()
-  config += buildHostConfig()
-  config += buildMongoConfig()
-  config += buildNginxConfig()
-  config += buildPostgresConfig()
+  config += buildHostConfig();
+  config += buildMongoConfig();
+  config += buildNginxConfig();
+  config += buildPostgresConfig();
 
-  return config
-}
+  return config;
+};


### PR DESCRIPTION
Oclif's eslint extensions cause eslint to crash when linting invalid syntax. This PR removes oclif & puts in typescripts recommend rules instead. Along with that, `eslint . --fix` has been ran to auto-fix most lint errors. That's why this PR is showing 40+ file changes