### PR TITLE
GUI: Fetch monitored services for sidebar & dashboard

### DIFF
--- a/src/components/Services/ChartSwitcher.tsx
+++ b/src/components/Services/ChartSwitcher.tsx
@@ -12,7 +12,7 @@ import NginxLogsCharts from './NginxLogs/Charts';
 import NginxMetricsCharts from './NginxMetrics/Charts';
 
 import PostgresLogsCharts from './PostgresLogs/Charts';
-import PostgresMetricsCharts from './PostgresMetrics/Charts';
+// import PostgresMetricsCharts from './PostgresMetrics/Charts';
 
 import Error from './Error';
 
@@ -41,7 +41,7 @@ export default function ChartSwitcher({ slug }: Props) {
     case "postgres-logs":
       return <PostgresLogsCharts />;
     case "postgres-metrics":
-      return <PostgresMetricsCharts />;
+      return <PostgresLogsCharts />;
     default:
       return <Error />;
   }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,20 +1,20 @@
 import 'tailwindcss/tailwind.css';
 import Head from 'next/head';
 import type { AppProps } from 'next/app';
-
+import { useState, useEffect } from 'react';
 import Sidebar from '../components/sidebar';
-import { MonitoredService } from '../constants/frontendTypes';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  // TODO: Fetch database tables
-  const services: MonitoredService[] = [
-    { name: 'postgres-metrics' },
-    { name: 'nginx-logs' },
-    { name: 'custom-application' },
-    { name: 'apache-logs' },
-    { name: 'mongo-metrics' },
-    { name: 'host-metrics' },
-  ];
+  const [services, setServices] = useState([]);
+
+  useEffect(()=> {
+    (async () => {
+      console.log('hit');
+      const res = await fetch("/api/tables");
+      const { data } = await res.json();
+      setServices(data);
+    })();
+  }, []);
 
   pageProps.services = services;
 

--- a/src/pages/api/tables.ts
+++ b/src/pages/api/tables.ts
@@ -1,10 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import listTables from "../../aws/orchestrator/listTables";
+import { MonitoredService, VectorService } from '../../constants/frontendTypes';
 
 export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   try {
     const tables = await listTables();
-    res.status(200).json({ tables });
+
+    const data: MonitoredService[] = [];
+    tables.forEach((table: { TableName: VectorService }) => {
+      data.push({ name: table.TableName });
+    });
+
+    res.status(200).json({ data });
   } catch (e) {
     console.log(e);
     res.status(500);


### PR DESCRIPTION
Hits AWS Timestream API for table names. We only create tables for services monitored by the user so this is a clever way of knowing what services are monitored across multiple computers.