### PR TITLE
Sound alarms on errors

### DIFF
--- a/src/aws/lambda/go/apache.go
+++ b/src/aws/lambda/go/apache.go
@@ -50,7 +50,7 @@ func apacheLogErrors(pRecord *RawRecord) {
 	// record := *pRecord
 	severity := fetch(pRecord, "level")
 	name := fetch(pRecord, "name")
-	measureValue := fetchMeasureValue(pRecord)
+	measureValue := fetchMV(pRecord)
 
 	if keyExists(*pRecord, "parsed") {
 		parsed := (*pRecord)["parsed"].(map[string]interface{})

--- a/src/aws/lambda/go/apache.go
+++ b/src/aws/lambda/go/apache.go
@@ -6,6 +6,30 @@ import (
 	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 )
 
+func apacheLogErrors(pRecord *RawRecord) {
+	severity := fetch(pRecord, "level")
+	name := fetch(pRecord, "name")
+	measureValue := fetchMV(pRecord)
+
+	if keyExists(*pRecord, "parsed") {
+		parsed := (*pRecord)["parsed"].(map[string]interface{})
+
+		statusCode := fetch(&parsed, "status")
+
+		if statusCode == "500" {
+			fmt.Println("[APACHE] Error: Status code 500")
+		}
+	}
+
+	if severity == "emerg" {
+		fmt.Println("[APACHE] Error: Fatal apache error")
+	}
+
+	if name == "up" && measureValue == "0.0" {
+		fmt.Println("[APACHE] Error: Apache web server is down")
+	}
+}
+
 func buildApacheAccessLogRecord(pRecord *RawRecord) {
 	record := *pRecord
 
@@ -44,32 +68,6 @@ func buildApacheAccessLogRecord(pRecord *RawRecord) {
 		Time:             &unixTime,
 		TimeUnit:         &timeUnit,
 	})
-}
-
-func apacheLogErrors(pRecord *RawRecord) {
-	// record := *pRecord
-	severity := fetch(pRecord, "level")
-	name := fetch(pRecord, "name")
-	measureValue := fetchMV(pRecord)
-
-	if keyExists(*pRecord, "parsed") {
-		parsed := (*pRecord)["parsed"].(map[string]interface{})
-
-		statusCode := fetch(&parsed, "status")
-
-		if statusCode == "500" {
-			fmt.Println("[APACHE] Error: Status code 500")
-		}
-	}
-
-	if severity == "emerg" {
-		fmt.Println("[APACHE] Error: Fatal apache error")
-	}
-
-	if name == "up" && measureValue == "0.0" {
-		fmt.Println("[APACHE] Error: Apache web server is down")
-	}
-
 }
 
 func buildApacheErrorLogRecord(pRecord *RawRecord) {

--- a/src/aws/lambda/go/host.go
+++ b/src/aws/lambda/go/host.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/aws/aws-sdk-go/service/timestreamwrite"
+import (
+	"github.com/aws/aws-sdk-go/service/timestreamwrite"
+)
 
 func buildHostMetricRecord(pRecord *RawRecord) {
 	record := *pRecord

--- a/src/aws/lambda/go/mongo.go
+++ b/src/aws/lambda/go/mongo.go
@@ -6,6 +6,24 @@ import (
 	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 )
 
+func mongoLogErrors(pRecord *RawRecord) {
+	name := fetch(pRecord, "name")
+	measureValue := fetchMV(pRecord)
+
+	if keyExists(*pRecord, "parsed") {
+		parsed := (*pRecord)["parsed"].(map[string]interface{})
+		severity := fetch(&parsed, "s")
+
+		if severity == "F" {
+			fmt.Println("[MONGO] Error: Fatal mongo error")
+		}
+	}
+
+	if name == "up" && measureValue == "0.0" {
+		fmt.Println("[MONGO] Error: Mongo server is down")
+	}
+}
+
 func buildMongoLogRecord(pRecord *RawRecord) {
 	record := *pRecord
 
@@ -52,26 +70,6 @@ func buildMongoLogRecord(pRecord *RawRecord) {
 		Time:             &unixTime,
 		TimeUnit:         &timeUnit,
 	})
-}
-
-func mongoLogErrors(pRecord *RawRecord) {
-
-	name := fetch(pRecord, "name")
-	measureValue := fetchMV(pRecord)
-
-	if keyExists(*pRecord, "parsed") {
-		parsed := (*pRecord)["parsed"].(map[string]interface{})
-
-		severity := fetch(&parsed, "s")
-
-		if severity == "F" {
-			fmt.Println("[MONGO] Error: Fatal mongo error")
-		}
-	}
-
-	if name == "up" && measureValue == "0.0" {
-		fmt.Println("[MONGO] Error: Mongo server is down")
-	}
 }
 
 func buildMongoMetricRecord(pRecord *RawRecord) {

--- a/src/aws/lambda/go/nginx.go
+++ b/src/aws/lambda/go/nginx.go
@@ -49,7 +49,7 @@ func nginxLogErrors(pRecord *RawRecord) {
 	statusCode := fetch(pRecord, "status")
 	severity := fetch(pRecord, "severity")
 	name := fetch(pRecord, "name")
-	measureValue := fetchMeasureValue(pRecord)
+	measureValue := fetchMV(pRecord)
 
 	if statusCode == "500" {
 		fmt.Println("[NGINX] Error: Status code 500")

--- a/src/aws/lambda/go/nginx.go
+++ b/src/aws/lambda/go/nginx.go
@@ -6,6 +6,25 @@ import (
 	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 )
 
+func nginxLogErrors(pRecord *RawRecord) {
+	statusCode := fetch(pRecord, "status")
+	severity := fetch(pRecord, "severity")
+	name := fetch(pRecord, "name")
+	measureValue := fetchMV(pRecord)
+
+	if statusCode == "500" {
+		fmt.Println("[NGINX] Error: Status code 500")
+	}
+
+	if severity == "emerg" {
+		fmt.Println("[NGINX] Error: Fatal nginx error")
+	}
+
+	if name == "up" && measureValue == "0.0" {
+		fmt.Println("[NGINX] Error: Nginx web server is down")
+	}
+}
+
 func buildNginxAccessLogRecord(pRecord *RawRecord) {
 	var dimensions []*timestreamwrite.Dimension
 	var timestamp string
@@ -42,27 +61,6 @@ func buildNginxAccessLogRecord(pRecord *RawRecord) {
 		Time:             &unixTime,
 		TimeUnit:         &timeUnit,
 	})
-}
-
-func nginxLogErrors(pRecord *RawRecord) {
-	// record := *pRecord
-	statusCode := fetch(pRecord, "status")
-	severity := fetch(pRecord, "severity")
-	name := fetch(pRecord, "name")
-	measureValue := fetchMV(pRecord)
-
-	if statusCode == "500" {
-		fmt.Println("[NGINX] Error: Status code 500")
-	}
-
-	if severity == "emerg" {
-		fmt.Println("[NGINX] Error: Fatal nginx error")
-	}
-
-	if name == "up" && measureValue == "0.0" {
-		fmt.Println("[NGINX] Error: Nginx web server is down")
-	}
-
 }
 
 func buildNginxErrorLogRecord(pRecord *RawRecord) {

--- a/src/aws/lambda/go/postgres.go
+++ b/src/aws/lambda/go/postgres.go
@@ -6,6 +6,20 @@ import (
 	"github.com/aws/aws-sdk-go/service/timestreamwrite"
 )
 
+func postgresLogErrors(pRecord *RawRecord) {
+	severity := fetch(pRecord, "level")
+	name := fetch(pRecord, "name")
+	measureValue := fetchMV(pRecord)
+
+	if severity == "FATAL" {
+		fmt.Println("[POSTGRES] Error: Fatal postgres error")
+	}
+
+	if name == "up" && measureValue == "0.0" {
+		fmt.Println("[POSTGRES] Error: Postgres server is down")
+	}
+}
+
 func buildPostgresLogRecord(pRecord *RawRecord) {
 	var dimensions []*timestreamwrite.Dimension
 	var timestamp string
@@ -37,21 +51,6 @@ func buildPostgresLogRecord(pRecord *RawRecord) {
 		Time:             &unixTime,
 		TimeUnit:         &timeUnit,
 	})
-}
-
-func postgresLogErrors(pRecord *RawRecord) {
-	severity := fetch(pRecord, "level")
-	name := fetch(pRecord, "name")
-	measureValue := fetchMV(pRecord)
-
-	if severity == "FATAL" {
-		fmt.Println("[POSTGRES] Error: Fatal postgres error")
-	}
-
-	if name == "up" && measureValue == "0.0" {
-		fmt.Println("[POSTGRES] Error: Postgres server is down")
-	}
-
 }
 
 func buildPostgresMetricRecord(pRecord *RawRecord) {

--- a/src/aws/lambda/go/timestream.go
+++ b/src/aws/lambda/go/timestream.go
@@ -53,7 +53,7 @@ func toUnix(timestamp string) string {
 	return fmt.Sprint(t.Unix())
 }
 
-func fetchMeasureValue(record *RawRecord) string {
+func fetchMV(record *RawRecord) string {
 	val, ok := (*record)["counter"]
 	if ok {
 		return fmt.Sprintf(
@@ -70,8 +70,17 @@ func fetchMeasureValue(record *RawRecord) string {
 		)
 	}
 
-	fmt.Printf("\nError: No counter or gauge for record: %s", (*record)["name"])
 	return ""
+}
+
+func fetchMeasureValue(record *RawRecord) string {
+	mv := fetchMV(record)
+
+	if mv == "" {
+		fmt.Printf("\nError: No counter or gauge for record: %s", (*record)["name"])
+	}
+
+	return mv
 }
 
 func buildRecordTypes(rawRecords *[]RawRecord) {


### PR DESCRIPTION
Raise alarms to send out an email where certain conditions are met. An example condition would be fatal errors for logs.